### PR TITLE
Add content to the covering letter, based on `covering_letter_type`

### DIFF
--- a/assets/markup/covering_letter.html.erb
+++ b/assets/markup/covering_letter.html.erb
@@ -13,6 +13,17 @@
   <div class="l-letter-content">
     <p>This document is a summary of the pension options discussed in your appointment. You’ll find key facts and next steps you can take to help you make a decision.</p>
 
+    <p>
+      <% case covering_letter_type
+         when 'section_32' %>
+        During the appointment we found that your pension pot may be a ‘Section 32’ arrangement. This could limit your options for taking your pension pot, eg you may not be able to take any tax-free cash. It could also limit your ability to transfer your pension to another pension provider or to take your pot earlier than the retirement date selected. Contact your current provider for more details.
+      <% when 'adjustable_income' %>
+        During the appointment we found that you may already be taking an adjustable income (known as ‘flexi-access drawdown’). This could mean you’re unable to use some of the pension options discussed. Contact your provider for more details.
+      <% when 'inherited_pot' %>
+        During the appointment we found you had inherited your pension pot. This could mean you’re unable to use some of the pension options discussed. The amount you pay in tax will be different from the information given under each option. For more information go to <a href="https://www.gov.uk/tax-on-pension-death-benefits">www.gov.uk/tax-on-pension-death-benefits</a> or you can contact your provider for more details.
+      <% end %>
+    </p>
+
     <p>Pension Wise is an impartial government service. We don’t recommend any products or tell you what to do with your money.</p>
 
     <p>Take your time and consider speaking to a regulated financial adviser to help you. You can now take money from your pot tax free to get financial advice on your pension. You can take £500 once a year and up to 3 times in total. Contact your provider for more details.</p>

--- a/features/covering_letter.feature
+++ b/features/covering_letter.feature
@@ -7,3 +7,21 @@ Scenario: Summary documents are sent with a covering letter
   Given a customer has had a Pension Wise appointment
   When we generate a summary document
   Then it should include a covering letter
+
+Scenario: Customer has a Section 32 arrangement pot
+  Given a customer has had a Pension Wise appointment
+  And the customer has a Section 32 arrangement pot
+  When we generate a summary document
+  Then the covering letter should have the Section 32 content
+
+Scenario: Customer taking an adjustable income
+  Given a customer has had a Pension Wise appointment
+  And the customer has an adjustable income
+  When we generate a summary document
+  Then the covering letter should have the adjustable income content
+
+Scenario: Customer has inherited their pension pot
+  Given a customer has had a Pension Wise appointment
+  And the customer has inherited their pension pot
+  When we generate a summary document
+  Then the covering letter should have the inherited pot content

--- a/features/step_definitions/covering_letter_steps.rb
+++ b/features/step_definitions/covering_letter_steps.rb
@@ -8,3 +8,27 @@ Then(/^it should include a covering letter$/) do
   expect(@rendered_template).to have_content(@output_document.attendee_name)
   expect(@rendered_template).to have_content(@output_document.lead)
 end
+
+Given(/^the customer has a Section 32 arrangement pot$/) do
+  @output_document.covering_letter_type = 'section_32'
+end
+
+Given(/^the customer has an adjustable income$/) do
+  @output_document.covering_letter_type = 'adjustable_income'
+end
+
+Given(/^the customer has inherited their pension pot$/) do
+  @output_document.covering_letter_type = 'inherited_pot'
+end
+
+Then(/^the covering letter should have the Section 32 content$/) do
+  expect(@rendered_template).to have_content('we found that your pension pot may be a ‘Section 32’ arrangement')
+end
+
+Then(/^the covering letter should have the adjustable income content$/) do
+  expect(@rendered_template).to have_content('we found that you may already be taking an adjustable income')
+end
+
+Then(/^the covering letter should have the inherited pot content$/) do
+  expect(@rendered_template).to have_content('we found you had inherited your pension pot')
+end

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -18,6 +18,7 @@ module Fixtures
                            'London',
                            'Greater London',
                            'SW1A 2HQ'].join("\n"),
+        covering_letter_type: 'section_32',
         appointment_date: '5 February 2015',
         guider_first_name: 'Penelope',
         lead: 'You recently had a Pension Wise guidance appointment with Penelope on 5 February 2015.',

--- a/lib/output/templates/version.rb
+++ b/lib/output/templates/version.rb
@@ -1,5 +1,5 @@
 module Output
   module Templates
-    VERSION = '4.7.1'.freeze
+    VERSION = '4.8.0'.freeze
   end
 end


### PR DESCRIPTION
The summary document generator will be adding a new multiple choice question to customise the covering letter based on customers who fit into one of three scenarios.

This will be passed down and set in the template using the `covering_letter_type` property.