### PR TITLE
Formally cover scenario where a `covering_letter_type` is not set

### DIFF
--- a/features/covering_letter.feature
+++ b/features/covering_letter.feature
@@ -25,3 +25,9 @@ Scenario: Customer has inherited their pension pot
   And the customer has inherited their pension pot
   When we generate a summary document
   Then the covering letter should have the inherited pot content
+
+Scenario: Customer has no cover letter customisation
+  Given a customer has had a Pension Wise appointment
+  And the customer has not customised their covering letter
+  When we generate a summary document
+  Then the covering letter should not have Section 32, adjustable income or inherited pot content

--- a/features/step_definitions/covering_letter_steps.rb
+++ b/features/step_definitions/covering_letter_steps.rb
@@ -21,6 +21,10 @@ Given(/^the customer has inherited their pension pot$/) do
   @output_document.covering_letter_type = 'inherited_pot'
 end
 
+Given(/^the customer has not customised their covering letter$/) do
+  @output_document.covering_letter_type = ''
+end
+
 Then(/^the covering letter should have the Section 32 content$/) do
   expect(@rendered_template).to have_content('we found that your pension pot may be a ‘Section 32’ arrangement')
 end
@@ -31,4 +35,10 @@ end
 
 Then(/^the covering letter should have the inherited pot content$/) do
   expect(@rendered_template).to have_content('we found you had inherited your pension pot')
+end
+
+Then(/^the covering letter should not have Section 32, adjustable income or inherited pot content$/) do
+  expect(@rendered_template).to_not have_content('we found that your pension pot may be a ‘Section 32’ arrangement')
+  expect(@rendered_template).to_not have_content('we found that you may already be taking an adjustable income')
+  expect(@rendered_template).to_not have_content('we found you had inherited your pension pot')
 end

--- a/lib/output/templates/version.rb
+++ b/lib/output/templates/version.rb
@@ -1,5 +1,5 @@
 module Output
   module Templates
-    VERSION = '4.8.1'.freeze
+    VERSION = '4.8.2'.freeze
   end
 end


### PR DESCRIPTION
No actual change to the templates, just ensure it's safe and include it in the features.