### PR TITLE
Pension Wise Digital URN

### DIFF
--- a/assets/markup/getting_started.html.erb
+++ b/assets/markup/getting_started.html.erb
@@ -10,6 +10,10 @@
 <!-- section: getting started -->
 <h2>Getting started</h2>
 
+<% if defined?(urn) && urn.present? %>
+<p class="summary t-urn">Your Pension Wise reference: <strong><%= urn %></strong></p>
+<% end %>
+
 <p class="summary">This is a summary of your defined contribution pension options. This is your personal or workplace pension and is based on how much has been paid into your pot.</p>
 
 <p class="emphasise">This is not a final salary or career average pension.</p>

--- a/features/step_definitions/summary_document_contents_steps.rb
+++ b/features/step_definitions/summary_document_contents_steps.rb
@@ -46,3 +46,15 @@ Then(/^the summary document should include the details of the appointment$/) do
   expect(@rendered_template).to have_content(@output_document.appointment_date)
   expect(@rendered_template).to have_content(@output_document.guider_first_name)
 end
+
+Then(/^the summary document does not include the Pension Wise Digital URN$/) do
+  expect(@rendered_template).not_to have_content('Your Pension Wise reference:')
+end
+
+Given(/^we have captured appointment details with a URN$/) do
+  @output_document = fixture(:output_document, urn: 'PWD1-2ABC')
+end
+
+Then(/^the summary document includes the Pension Wise Digital URN$/) do
+  expect(@rendered_template).to have_content('Your Pension Wise reference: PWD1-2ABC')
+end

--- a/features/summary_document_contents.feature
+++ b/features/summary_document_contents.feature
@@ -38,3 +38,9 @@ Scenario: Summary documents include information about the appointment
   Given we have captured appointment details
   When we generate a summary document
   Then the summary document should include the details of the appointment
+  And the summary document does not include the Pension Wise Digital URN
+
+Scenario: Pension Wise Digital Summary includes the URN
+  Given we have captured appointment details with a URN
+  When we generate a summary document
+  Then the summary document includes the Pension Wise Digital URN

--- a/lib/output/templates/version.rb
+++ b/lib/output/templates/version.rb
@@ -1,5 +1,5 @@
 module Output
   module Templates
-    VERSION = '6.13.0'.freeze
+    VERSION = '6.14.0'.freeze
   end
 end


### PR DESCRIPTION
Provides a means for clients to specify a `urn` and have this presented in the output document.